### PR TITLE
docs(readme): fix potential issue in housekeeping

### DIFF
--- a/README.md
+++ b/README.md
@@ -921,11 +921,11 @@ git branch -r | grep 'origin' | grep --invert-match 'master$' | grep --invert-ma
 
 ```sh
 # Delete all local tags that do NOT match a pattern of a semantic version (MAJOR.MINOR.PATCH), e.g. ods-generated-v20220518.001, v1.0.0-next.5
-git tag -l | grep --invert-match '^v[[:digit:]].[[:digit:]].[[:digit:]]$' | xargs git tag -d
+git tag -l | grep --invert-match '^v[[:digit:]]*.[[:digit:]]*.[[:digit:]]*$' | xargs git tag -d
 
 # Delete all remote tags that do NOT match a pattern of a semantic version (MAJOR.MINOR.PATCH), e.g. ods-generated-v20220518.001, v1.0.0-next.5
 # Skip git hooks with '--no-verify'
-git ls-remote --tags origin | cut -d/ -f3- | grep --invert-match '^v[[:digit:]].[[:digit:]].[[:digit:]]$' | grep -v '}$' | xargs git push --delete --no-verify origin
+git ls-remote --tags origin | cut -d/ -f3- | grep --invert-match '^v[[:digit:]]*.[[:digit:]]*.[[:digit:]]*$' | grep -v '}$' | xargs git push --delete --no-verify origin
 ```
 
 ### OpenShift


### PR DESCRIPTION
Exclude tags with multiple digits per position for MAJOR, MINOR and PATCH-Versions while housekeeping.

Since the `[:digit:]]` regex allows only one digit per position, tags with version numbers >9 are deleted during housekeeping (affects MAJOR, MINOR and PATCH). For example, tags in the form 1.0.10 will be deleted. This can lead to consequential problems during publishing.
This PR allows multiple digits per position via `[[:digit:]]*` for MAJOR, MINOR and PATCH versions, which means that these tags will not be deleted during housekeeping. 